### PR TITLE
[delete] Update duplicate_verts filter name

### DIFF
--- a/meshlabxml/delete.py
+++ b/meshlabxml/delete.py
@@ -187,7 +187,11 @@ def duplicate_verts(script):
         2016.12
         1.3.4BETA
     """
-    filter_xml = '  <filter name="Remove Duplicated Vertex"/>\n'
+    if script.ml_version == '1.3.4BETA':
+        filter_xml = '  <filter name="Remove Duplicated Vertex"/>\n'
+    else:
+        filter_xml = '  <filter name="Remove Duplicate Vertices"/>\n'
+
     util.write_filter(script, filter_xml)
     return None
 


### PR DESCRIPTION
For versions other than 1.3.4BETA, the filter name to remove duplicate verticies has changed to "Remove Duplicate Verticies". This change corrects the error "filter Remove Duplicated Vertext not found" when trying to run delete.duplicate_verts() when using ML 2016.12