### PR TITLE
fix parameter name in close_holes for version 1.3.4BETA

### DIFF
--- a/meshlabxml/clean.py
+++ b/meshlabxml/clean.py
@@ -65,7 +65,7 @@ def close_holes(script, hole_max_edge=30, selected=False,
     """
     filter_xml = ''.join([
         '  <filter name="Close Holes">\n',
-        '    <Param name="maxholesize" ',
+        '    <Param name="MaxHoleSize" ',
         'value="{:d}" '.format(hole_max_edge),
         'description="Max size to be closed" ',
         'type="RichInt" ',


### PR DESCRIPTION
Hi, 

I noticed that the Close-Holes-Filter requires a slightly different parameter name. I couldn't test it with the other version (2016.12), maybe an if-else is required. 
And thanks for creating this library!